### PR TITLE
Updates for MPB 0.4 and drop support for Julia 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.3
   - 0.4
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,10 +1,9 @@
-julia 0.3
-Compat
+julia 0.4
 Clp
 Cbc
 Ipopt
 LightXML 0.2
 BinDeps
-MathProgBase 0.3 0.4
+MathProgBase 0.4.0 0.5.0-
 @osx Homebrew
 @windows WinRPM

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,4 @@
-using BinDeps, Compat
+using BinDeps
 
 @BinDeps.setup
 

--- a/src/probmod.jl
+++ b/src/probmod.jl
@@ -68,8 +68,8 @@ function initialize_quadcoefs!(m::OsilMathProgModel)
     # return numberOfQuadraticTerms if quadraticCoefficients has been
     # created, otherwise create quadraticCoefficients and return 0
     if isdefined(m, :quadraticCoefficients)
-        return @compat(parse(Int, attribute(m.quadraticCoefficients,
-            "numberOfQuadraticTerms")))
+        return parse(Int, attribute(m.quadraticCoefficients,
+            "numberOfQuadraticTerms"))
     else
         m.quadraticCoefficients = new_child(m.instanceData,
             "quadraticCoefficients")
@@ -257,8 +257,8 @@ function MathProgBase.addvar!(m::OsilMathProgModel, lb, ub, objcoef)
     push!(m.xu, ub)
     newvar!(m.variables, lb, ub)
     if objcoef != 0.0
-        set_attribute(m.obj, "numberOfObjCoef", @compat(parse(Int,
-            attribute(m.obj, "numberOfObjCoef"))) + 1)
+        set_attribute(m.obj, "numberOfObjCoef", parse(Int,
+            attribute(m.obj, "numberOfObjCoef"))) + 1
         # use old numberOfVariables since OSiL is 0-based
         newobjcoef!(m.obj, m.numberOfVariables, objcoef)
     end
@@ -290,8 +290,8 @@ function MathProgBase.addconstr!(m::OsilMathProgModel, varidx, coef, lb, ub)
             rowstarts = find_element(linConstrCoefs, "start")
             colIdx = find_element(linConstrCoefs, "colIdx")
             values = find_element(linConstrCoefs, "value")
-            numberOfValues = @compat(parse(Int,
-                attribute(linConstrCoefs, "numberOfValues")))
+            numberOfValues = parse(Int,
+                attribute(linConstrCoefs, "numberOfValues"))
         end
     end
     numdupes = 0
@@ -403,4 +403,32 @@ end
 
 # TODO: setquadconstrRHS!, getconstrsolution, getconstrmatrix, getrawsolver,
 # getsolvetime, sos constraints, basis, infeasibility/unbounded rays?
+
+# General wrapper functions
+for f in [:getsolution,:getobjval,:optimize!,:status,:getsense,:numvar,:numconstr,:getvartype,:getreducedcosts,:getconstrduals]
+    @eval $f(m::OsilNonlinearModel) = $f(m.inner)
+    @eval $f(m::OsilLinearQuadraticModel) = $f(m.inner)
+end
+for f in [:setsense!,:setvartype!,:setwarmstart!]
+    @eval $f(m::OsilNonlinearModel, x) = $f(m.inner, x)
+    @eval $f(m::OsilLinearQuadraticModel, x) = $f(m.inner, x)
+end
+
+# LinearQuadratic wrapper functions
+for f in [:numlinconstr,:numquadconstr,:getquadconstrduals,:getvarLB,:getvarUB,:getconstrLB,:getconstrUB,:getobj]
+    @eval $f(m::OsilLinearQuadraticModel) = $f(m.inner)
+end
+for f in [:setobj!,:setvarLB!,:setvarUB!,:setconstrLB!,:setconstrUB!]
+    @eval $f(m::OsilLinearQuadraticModel, x) = $f(m.inner, x)
+end
+for f in [:addvar!, :setquadobjterms!]
+    @eval $f(m::OsilLinearQuadraticModel, x, y, z) = $f(m.inner, x, y, z)
+end
+for f in [:addconstr!]
+    @eval $f(m::OsilLinearQuadraticModel, w, x, y, z) = $f(m.inner, w, x, y, z)
+end
+for f in [:addquadconstr!]
+    @eval $f(m::OsilLinearQuadraticModel, a, b, c, d, e, f, g) =
+        $f(m.inner, a, b, c, d, e, f, g)
+end
 

--- a/src/translations.jl
+++ b/src/translations.jl
@@ -1,11 +1,11 @@
-jl2osnl_varargs = @compat Dict(
+jl2osnl_varargs = Dict(
     :+     => "sum",
     :*     => "product")
 
 jl2osnl_ternary = copy(jl2osnl_varargs)
 jl2osnl_ternary[:ifelse] = "if"
 
-jl2osnl_binary = @compat Dict(
+jl2osnl_binary = Dict(
     :+     => "plus",
     :.+    => "plus",
     :-     => "minus",
@@ -22,7 +22,7 @@ jl2osnl_binary = @compat Dict(
     :.^    => "power",
     :log   => "log")
 
-jl2osnl_unary = @compat Dict(
+jl2osnl_unary = Dict(
     :-     => "negate",
     :√     => "sqrt",
     :abs2  => "square",
@@ -48,7 +48,7 @@ for op in [:abs, :sqrt, :floor, :factorial, :exp, :sign, :erf,
     jl2osnl_unary[op] = string(op)
 end
 
-jl2osnl_comparison = @compat Dict(
+jl2osnl_comparison = Dict(
     :<     => "lt",
     :<=    => "leq",
     :≤     => "leq",
@@ -60,11 +60,11 @@ jl2osnl_comparison = @compat Dict(
     :≠     => "neq")
 # and, or, xor, not?
 
-jl2osil_vartypes = @compat Dict(:Cont => "C", :Int => "I", :Bin => "B",
+jl2osil_vartypes = Dict(:Cont => "C", :Int => "I", :Bin => "B",
     :SemiCont => "D", :SemiInt => "J", :Fixed => "C")
 # assuming lb == ub for all occurrences of :Fixed vars
 
-osrl2jl_status = @compat Dict(
+osrl2jl_status = Dict(
     "unbounded" => :Unbounded,
     "globallyOptimal" => :Optimal,
     "locallyOptimal" => :Optimal,
@@ -174,7 +174,7 @@ end
 function expr2osnl!(parent, ex)
     # for anything not an Expr, assume it's a constant number
     child = new_child(parent, "number")
-    set_attribute(child, "value", @compat Float64(ex))
+    set_attribute(child, "value", Float64(ex))
     return child
 end
 
@@ -245,12 +245,12 @@ function xml2vec(el::XMLElement, n::Integer, defaultval=NaN)
     x = fill(defaultval, n)
     indicator = fill(false, n)
     for child in child_elements(el)
-        idx = @compat parse(Int, attribute(child, "idx")) + 1 # OSiL is 0-based
+        idx = parse(Int, attribute(child, "idx")) + 1 # OSiL is 0-based
         if indicator[idx] # combine duplicates
-            x[idx] += @compat parse(Float64, content(child))
+            x[idx] += parse(Float64, content(child))
         else
             indicator[idx] = true
-            x[idx] = @compat parse(Float64, content(child))
+            x[idx] = parse(Float64, content(child))
         end
     end
     return x

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,2 @@
-JuMP 0.7 0.10
-# TODO: remove jump upper bound if #6 can be fixed
+JuMP 0.7
 FactCheck


### PR DESCRIPTION
Ref JuliaOpt/MathProgBase.jl#91 and JuliaOpt/AmplNLWriter.jl#24, using the same wrapper approach as AmplNLWriter.

The two Linux failures are [this error](https://github.com/JuliaOpt/CoinOptServices.jl/issues/6#issuecomment-128133851) from #6 when using Couenne.

The failures on Mac are the same MIQP vectorized problem, but due to tolerance issues with the optimal solution, again when using Couenne.

It would be possible to make the tests pass by removing Couenne from `quad_mip_solvers`, if that was something we wanted to do, but otherwise everything seems fine.