### PR TITLE
fill reduced costs vector if none is provided by solver

### DIFF
--- a/src/CoinOptServices.jl
+++ b/src/CoinOptServices.jl
@@ -466,6 +466,9 @@ function read_osrl_file!(m::OsilMathProgModel, osrl)
                 end
             end
         end
+        if !reduced_costs_found
+            m.reducedcosts = fill(NaN, m.numberOfVariables)
+        end
         numberOfOther = attribute(variables, "numberOfOtherVariableResults")
         if numberOfOther == nothing
             @assertequal(counter, 0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,5 +22,15 @@ m = Model(solver = OsilSolver())
 
 solve(m)
 
+# Issue #13
+nvar = 10
+solver=OsilSolver(solver = "couenne")
+m = Model(solver=solver)
+@defVar(m, -10 <= x[i=1:nvar] <= 10)
+@setNLObjective(m, Min, sum{1/(1+exp(-x[i])), i=1:nvar})
+@addConstraint(m, sum{x[i], i=1:nvar} <= .4*nvar)
+@test solve(m) == :Optimal
+@test isapprox(getValue(x[1]),-10.0)
+
 
 include(Pkg.dir("JuMP","test","runtests.jl"))


### PR DESCRIPTION
Fixes #13 
CC @madeleineudell 