### PR TITLE
Handle changes to comparison parsing in Julia 0.5. Fixes #16

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,6 +4,6 @@ Cbc
 Ipopt
 LightXML 0.2
 BinDeps
-MathProgBase 0.4.0 0.5.0-
+MathProgBase 0.5.0 0.6.0-
 @osx Homebrew
 @windows WinRPM

--- a/src/translations.jl
+++ b/src/translations.jl
@@ -20,7 +20,17 @@ jl2osnl_binary = Dict(
     :rem   => "rem",
     :^     => "power",
     :.^    => "power",
-    :log   => "log")
+    :log   => "log",
+    :<     => "lt",
+    :<=    => "leq",
+    :≤     => "leq",
+    :>     => "gt",
+    :>=    => "geq",
+    :≥     => "geq",
+    :(==)  => "eq",
+    :!=    => "neq",
+    :≠     => "neq")
+# and, or, xor, not?
 
 jl2osnl_unary = Dict(
     :-     => "negate",
@@ -48,17 +58,19 @@ for op in [:abs, :sqrt, :floor, :factorial, :exp, :sign, :erf,
     jl2osnl_unary[op] = string(op)
 end
 
-jl2osnl_comparison = Dict(
-    :<     => "lt",
-    :<=    => "leq",
-    :≤     => "leq",
-    :>     => "gt",
-    :>=    => "geq",
-    :≥     => "geq",
-    :(==)  => "eq",
-    :!=    => "neq",
-    :≠     => "neq")
-# and, or, xor, not?
+if VERSION < v"0.5.0-dev+3231"
+    jl2osnl_comparison = Dict(
+        :<     => "lt",
+        :<=    => "leq",
+        :≤     => "leq",
+        :>     => "gt",
+        :>=    => "geq",
+        :≥     => "geq",
+        :(==)  => "eq",
+        :!=    => "neq",
+        :≠     => "neq")
+    # and, or, xor, not?
+end
 
 jl2osil_vartypes = Dict(:Cont => "C", :Int => "I", :Bin => "B",
     :SemiCont => "D", :SemiInt => "J", :Fixed => "C")
@@ -155,7 +167,7 @@ function expr2osnl!(parent, ex::Expr)
     elseif head == :ref
         child = var2osnl!(parent, args)
     elseif head == :comparison
-        if numargs == 3
+        if VERSION < v"0.5.0-dev+3231" && numargs == 3
             if haskey(jl2osnl_comparison, args[2])
                 child = new_child(parent, jl2osnl_comparison[args[2]])
                 expr2osnl!(child, args[1])


### PR DESCRIPTION
I copied over the changes from AmplNLWriter.jl that were needed to fix the comparison changes as per #16. The situation after the change with the comparison and binary operator dicts isn't that nice, but eventually the comparison one (and associated special casing) will go away I guess. Feel free to build on top of this if you wanted to do anything differently.