### PR TITLE
OsilNonlinearModel should be an AbstractNonlinearModel

### DIFF
--- a/src/CoinOptServices.jl
+++ b/src/CoinOptServices.jl
@@ -132,7 +132,7 @@ end
 immutable OsilLinearQuadraticModel <: AbstractLinearQuadraticModel
     inner::OsilMathProgModel
 end
-immutable OsilNonlinearModel <: AbstractLinearQuadraticModel
+immutable OsilNonlinearModel <: AbstractNonlinearModel
     inner::OsilMathProgModel
 end
 


### PR DESCRIPTION
Having the wrong type here breaks some JuMP behavior, e.g., https://github.com/JuliaOpt/JuMP.jl/pull/770