### PR TITLE
Maintenance for Julia v0.5 and JuMP v0.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 Clp
 Cbc
 Ipopt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ environment:
   matrix:
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -8,14 +8,14 @@ version = "2.9.2"
 provides(Sources, URI("http://www.coin-or.org/download/source/OS/OS-$version.tgz"),
     [libOS], os = :Unix)
 
-@windows_only begin
+@static if is_windows()
     using WinRPM
     push!(WinRPM.sources, "http://download.opensuse.org/repositories/home:/kelman:/mingw-coinor/openSUSE_13.2")
     WinRPM.update()
     provides(WinRPM.RPM, "OptimizationServices", [libOS], os = :Windows)
 end
 
-@osx_only begin
+@static if is_apple()
     using Homebrew
     provides(Homebrew.HB, "Optimizationservices", [libOS], os = :Darwin)
 end
@@ -33,8 +33,10 @@ patchdir = BinDeps.depsdir(libOS)
 builddir = joinpath(BinDeps.depsdir(libOS), "src", "OS-$version", "build")
 
 ENV2 = copy(ENV)
-@unix_only ENV2["PKG_CONFIG_PATH"] = string(joinpath(cbclibdir, "pkgconfig"),
+@static if is_unix()
+    ENV2["PKG_CONFIG_PATH"] = string(joinpath(cbclibdir, "pkgconfig"),
     ":", joinpath(ipoptlibdir, "pkgconfig"))
+end
 cbcincdir = joinpath(cbclibdir, "..", "include", "coin")
 
 provides(SimpleBuild,

--- a/src/CoinOptServices.jl
+++ b/src/CoinOptServices.jl
@@ -26,10 +26,10 @@ osildir = Pkg.dir("CoinOptServices", ".osil")
 
 export OsilSolver, OsilBonminSolver, OsilCouenneSolver, OSOption
 immutable OsilSolver <: AbstractMathProgSolver
-    solver::UTF8String
-    osil::UTF8String
-    osol::UTF8String
-    osrl::UTF8String
+    solver::String
+    osil::String
+    osol::String
+    osrl::String
     printLevel::Int
     options::Vector{Dict}
 end
@@ -89,10 +89,10 @@ OSOption(optname, optval; kwargs...) =
     OSOption(name = optname, value = optval; kwargs...)
 
 type OsilMathProgModel <: AbstractMathProgModel
-    solver::UTF8String
-    osil::UTF8String
-    osol::UTF8String
-    osrl::UTF8String
+    solver::String
+    osil::String
+    osol::String
+    osrl::String
     printLevel::Int
     options::Vector{Dict}
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,3 @@
-JuMP 0.13
+JuMP 0.15
 OffsetArrays 0.2.13
 FactCheck

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 JuMP 0.13
+OffsetArrays 0.2.13
 FactCheck

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,10 +27,10 @@ nvar = 10
 solver=OsilSolver(solver = "couenne")
 m = Model(solver=solver)
 @variable(m, -10 <= x[i=1:nvar] <= 10)
-@NLobjective(m, Min, sum{1/(1+exp(-x[i])), i=1:nvar})
-@constraint(m, sum{x[i], i=1:nvar} <= .4*nvar)
+@NLobjective(m, Min, sum(1/(1+exp(-x[i])) for i in 1:nvar))
+@constraint(m, sum(x[i] for i in 1:nvar) <= .4*nvar)
 @test solve(m) == :Optimal
-@test isapprox(getvalue(x[1]),-10.0)
+@test isapprox(getvalue(x[1]), -10.0)
 
 
 include(Pkg.dir("JuMP","test","runtests.jl"))


### PR DESCRIPTION
Standard stuff.  Dropping Julia v0.4 support.  The version lb on MPB might need to be updated, please advise.  

Also, would be open to working on v0.6 compatibility in this PR, but need a hint on why this is breaking?  See, https://travis-ci.org/ccoffrin/CoinOptServices.jl/jobs/217027340.